### PR TITLE
Increase compatibility by using /usr/bin/env

### DIFF
--- a/ImagePyX.py
+++ b/ImagePyX.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#! /usr/bin/env python2
 '''
 ImagePyX.py - Super Simple WIM Manager
 Driver main module


### PR DESCRIPTION
`python2` is not always going to be stored in `/usr/bin/`. Indeed, macOS stores it in `/usr/local/bin/`. However, much more common is having `/usr/bin/env` which will call another interpreter from the path.